### PR TITLE
UPdated for showing project name in report if the build is from Jenkins

### DIFF
--- a/src/main/resources/templates/featureOverview.vm
+++ b/src/main/resources/templates/featureOverview.vm
@@ -97,6 +97,9 @@ table.stats-table td {
 		<div class="container_12">
 			<div class="grid_9 heading">
 				<h2 id="overview-title">Feature Overview for Build: $build_number</h2>
+				 #if($fromJenkins)
+				<h2 id="overview-project">Project Name: $build_project</h2>
+				#end
 				<span class="subhead">The following graph shows passing and failing statistics for features in this build:</span>
 			</div>
 		</div>

--- a/src/main/resources/templates/tagOverview.vm
+++ b/src/main/resources/templates/tagOverview.vm
@@ -340,6 +340,9 @@
     <div class="container_12">
         <div class="grid_9 heading">
             <h2>Tag Overview for Build: $build_number</h2>
+            #if($fromJenkins)
+			<h2 id="overview-project">Project Name: $build_project</h2>
+			#end
             <span class="subhead">The following graph shows number of steps passing, failing and skipped for this build:</span>
         </div>
     </div>


### PR DESCRIPTION
The project name is not shown in the report. Which causes a problem if we have multiple projects and each publishing the reports. With this change it becomes easier for the user to identify the project for which the report is intended 