### PR TITLE
Added lint to previous build:

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportBuilder.java
+++ b/src/main/java/net/masterthought/cucumber/ReportBuilder.java
@@ -328,13 +328,22 @@ public class ReportBuilder {
         return props;
     }
 
-    private HashMap<String, Object> getGeneralParameters() {
-        HashMap<String, Object> result = new HashMap<String, Object>();
+    private Map<String, Object> getGeneralParameters() {
+        Map<String, Object> result = new HashMap<String, Object>();
         result.put("version", VERSION);
         result.put("fromJenkins", runWithJenkins);
         result.put("jenkins_base", pluginUrlPath);
         result.put("build_project", buildProject);
         result.put("build_number", buildNumber);
+        int previousBuildNumber = -1;
+        try {
+            previousBuildNumber = Integer.parseInt(buildNumber);
+            previousBuildNumber--;
+        } catch (NumberFormatException e) {
+            // could not parse build number, probably not valid int value
+        }
+        result.put("previous_build_number", previousBuildNumber);
+
         return result;
     }
 }

--- a/src/main/resources/templates/featureOverview.vm
+++ b/src/main/resources/templates/featureOverview.vm
@@ -89,6 +89,9 @@ table.stats-table td {
 				<ul>
                     #if($fromJenkins)
                         <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                        #if($previous_build_number != -1)
+                            <li><a href="${jenkins_base}job/$build_project/$previous_build_number/cucumber-html-reports/feature-overview.html">Previous Build</a></li>
+                        #end
                     #end
 				<li><a href="tag-overview.html">Tag Overview</a></li>
 				</ul>

--- a/src/main/resources/templates/featureReport.vm
+++ b/src/main/resources/templates/featureReport.vm
@@ -161,7 +161,10 @@ table.data-table td {
 			<div class="grid_6" id="nav">
 				<ul>
                     #if($fromJenkins)
-                          <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                        <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                        #if($previous_build_number != -1)
+                            <li><a href="${jenkins_base}job/$build_project/$previous_build_number/cucumber-html-reports/$feature.getFileName()">Previous Build</a></li>
+                        #end
                     #end
 					<li><a href="tag-overview.html">Tag Overview</a></li>
 					<li><a href="feature-overview.html">Feature Overview</a></li>

--- a/src/main/resources/templates/tagOverview.vm
+++ b/src/main/resources/templates/tagOverview.vm
@@ -341,7 +341,10 @@
         <div class="grid_6" id="nav">
             <ul>
                 #if($fromJenkins)
-                  <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                    <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                    #if($previous_build_number != -1)
+                        <li><a href="${jenkins_base}job/$build_project/$previous_build_number/cucumber-html-reports/tag-overview.html">Previous Build</a></li>
+                    #end
                 #end
                 <li><a href="feature-overview.html">Feature Overview</a></li>
             </ul>
@@ -353,8 +356,11 @@
         <div class="grid_9 heading">
             <h2>Tag Overview for Build: $build_number</h2>
             #if($fromJenkins)
-			<h2 id="overview-project">Project Name: $build_project</h2>
-			#end
+            <h2 id="overview-project">Project Name: $build_project</h2>
+                #if($previous_build_number != -1)
+                    <li><a href="${jenkins_base}job/$build_project/$previous_build_number/cucumber-html-reports/feature-overview.html">Previous Build</a></li>
+                #end
+            #end
             <span class="subhead">The following graph shows number of steps passing, failing and skipped for this build:</span>
         </div>
     </div>

--- a/src/main/resources/templates/tagReport.vm
+++ b/src/main/resources/templates/tagReport.vm
@@ -114,7 +114,10 @@ table.data-table td {
             <div class="grid_6" id="nav">
                 <ul>
                     #if($fromJenkins)
-                      <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                        <li><a href="${jenkins_base}job/$build_project/$build_number">Back To Jenkins</a></li>
+                        #if($previous_build_number != -1)
+                            <li><a href="${jenkins_base}job/$build_project/$previous_build_number/cucumber-html-reports/$tag.getFileName()">Previous Build</a></li>
+                        #end
                     #end
                     <li><a href="feature-overview.html">Feature Overview</a></li>
                     <li><a href="tag-overview.html">Tag Overview</a></li>


### PR DESCRIPTION
- since report has no information about previous build I've added link to the header when build number > 1
- previous link directs to the same page of previous build (not the main) so comparing results is easier

Issue #33