### PR TITLE
fixed cucumberjs report displaying After hook as being a step

### DIFF
--- a/src/main/java/net/masterthought/cucumber/json/Step.java
+++ b/src/main/java/net/masterthought/cucumber/json/Step.java
@@ -21,6 +21,7 @@ public class Step {
 
     private String name;
     private String keyword;
+    private boolean hidden;
     private String line;
     private Result result;
     private Row[] rows;
@@ -31,6 +32,10 @@ public class Step {
 
     public Step() {
 
+    }
+    
+    public boolean isHidden() {
+        return hidden;
     }
 
     public DocString getDocString() {
@@ -72,10 +77,12 @@ public class Step {
     }
 
     public Status getStatus() {
-        if (result == null) {
+        if (result == null && !isHidden()) {
             System.out.println("[WARNING] Line " + line + " : " + "Step is missing Result: " + keyword + " : " + name);
             return Status.MISSING;
-        } else {
+        } else if (isHidden()) {
+            return Status.HIDDEN;
+        }else {
             return Status.valueOf(result.getStatus().toUpperCase());
         }
     }

--- a/src/main/java/net/masterthought/cucumber/util/Status.java
+++ b/src/main/java/net/masterthought/cucumber/util/Status.java
@@ -13,7 +13,8 @@ public enum Status {
     SKIPPED("#88AAFF"),
     PENDING("#FBB907"),
     UNDEFINED("#FBB957"),
-    MISSING("#FBB9A7");
+    MISSING("#FBB9A7"),
+    HIDDEN("");
 
     /** Color representation for given status. */
     public final String color;

--- a/src/main/resources/styles/reporting.css
+++ b/src/main/resources/styles/reporting.css
@@ -57,6 +57,10 @@
 	background-color: #C5D88A;
 }
 
+.hidden {
+	visibility: hidden;
+}
+
 .failed {
 	background-color: #D88A8A;
 }


### PR DESCRIPTION
cucumberjs generates an extra attribute in the step json, causing the HTML report to display that step, and to look 'ugly'
```json
          {
            "keyword": "After ",
            "hidden": true,
            "result": {
              "duration": 1456494,
              "status": "passed"
            },
            "match": {}
          }
```
![after step shown](https://cloud.githubusercontent.com/assets/8307102/7609856/217bb7b4-f980-11e4-8aec-24bfd99dff95.PNG)

with the current impl, the step is being hidden, and if that step has attachments, they will remain visible.
![after2](https://cloud.githubusercontent.com/assets/8307102/7609879/68d8c2c8-f980-11e4-8023-94dc207eb71a.PNG)

![after3](https://cloud.githubusercontent.com/assets/8307102/7609886/8368bbf2-f980-11e4-92bd-1620d9e4830e.PNG)
![after4](https://cloud.githubusercontent.com/assets/8307102/7609910/bb4293cc-f980-11e4-8655-ae90064ffbce.PNG)




